### PR TITLE
Add American Express internship

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,4 @@ We provide our community members with **company-specific interview questions**, 
 |[Qualcomm (Software Engineering)](https://jobs.qualcomm.com/public/jobDetails.xhtml?requisitionId=1982304)|San Diego, Boulder, Austin|C/C++|
 |[Qualcomm (Hardware Engineering)](https://jobs.qualcomm.com/public/jobDetails.xhtml?requisitionId=1982302)|San Diego|C/C++|
 |[IMC](https://careers.imc.com/us/en/job/REQ-00813/Software-Engineer-Intern-Summer-2021)|Chicago|C++, Java|
+|[American Express](https://jobs.americanexpress.com/jobs/20001627)|Phoenix, Ft. Lauderdale, New York|Java, JavaScript, .NET, Graduating between December 2021 and June 2023|


### PR DESCRIPTION
This patch adds the opening for Amex's "Campus – 2021 Technology Software Engineer Internship."